### PR TITLE
Fix screen jumpness when textarea is taller than browser window

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ var TextareaAutosize = React.createClass({
     var node = this.getDOMNode();
     
     // Record the X and Y screen position so the window doesn't bounce if
-    // The textarea is longer than the whole screen.
+    // the textarea is longer than the whole screen.
     var currentScrollPositionX = window.pageXOffset;
     var currentScrollPositionY = window.pageYOffset;
     node.style.height = 'auto';

--- a/index.js
+++ b/index.js
@@ -74,8 +74,15 @@ var TextareaAutosize = React.createClass({
     }
 
     var node = this.getDOMNode();
+    
+    // Record the X and Y screen position so the window doesn't bounce if
+    // The textarea is longer than the whole screen.
+    var currentScrollPositionX = window.pageXOffset;
+    var currentScrollPositionY = window.pageYOffset;
     node.style.height = 'auto';
     node.style.height = (node.scrollHeight - diff) + 'px';
+    // Set the X and Y screen position to the stored values.
+    window.scrollTo(currentScrollPositionX, currentScrollPositionY);
   }
 });
 


### PR DESCRIPTION
When the textarea is taller than the browser, the screen jumps occasionally when you try to edit the textarea's content. This PR fixes that issue.
