### PR TITLE
allow styles to change overflow

### DIFF
--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -47,8 +47,8 @@ export default class TextareaAutosize extends React.Component {
       props.value = this.props.valueLink.value;
     }
     props.style = {
-      ...props.style,
       overflow: 'hidden',
+      ...props.style,
       height: this.state.height
     };
     return <textarea {...props} onChange={this._onChange} />;


### PR DESCRIPTION
E.g.

I have a textarea for editing that needs autosize but also is affixed.

When the content is too long I set a maxHeight so that the affix doesn't drop off the bottom of the page.. but now I wish to set `overflow: auto` so that textarea can be scrolled.