### PR TITLE
Check if we're on server or not

### DIFF
--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -98,10 +98,14 @@ export default class TextareaAutosize extends React.Component {
 
 }
 
-let onNextFrame = window.requestAnimationFrame;
+if (process.browser) {
 
-if (onNextFrame === undefined) {
-  onNextFrame = function onNextFrame(cb) {
-    window.setTimeout(cb, 1);
-  };
+  let onNextFrame = window.requestAnimationFrame;
+
+  if (onNextFrame === undefined) {
+    onNextFrame = function onNextFrame(cb) {
+      window.setTimeout(cb, 1);
+    };
+  }
+
 }


### PR DESCRIPTION
This check fixes server errors, where `window` is not defined.