### PR TITLE
fix border-related calculations in some browsers

### DIFF
--- a/src/calculateNodeHeight.js
+++ b/src/calculateNodeHeight.js
@@ -94,8 +94,8 @@ function calculateNodeStyling(node, useCache = false) {
   // border-box: add border, since height = content + padding + border
   if (boxSizing === 'border-box') {
     heightAdjustment = (
-      parseFloat(compStyle.getPropertyValue('border-bottom')) +
-      parseFloat(compStyle.getPropertyValue('border-top'))
+      parseFloat(compStyle.getPropertyValue('border-bottom-width')) +
+      parseFloat(compStyle.getPropertyValue('border-top-width'))
     );
   } else if (boxSizing === 'content-box') { // remove padding, since height = content
     heightAdjustment = -(


### PR DESCRIPTION
this broke for some browsers in 9b65e4d2, since they just return an empty string for border-top/border-bottom... sorry about that, should have tested the previous commit in more than just chrome :(