### PR TITLE
clear next frame action before scheduling another

### DIFF
--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -91,6 +91,7 @@ export default class TextareaAutosize extends React.Component {
 
   componentWillReceiveProps() {
     // Re-render with the new content then recalculate the height as required.
+    this.clearNextFrame();
     this.onNextFrameActionId = onNextFrame(this._resizeComponent);
   }
 
@@ -104,6 +105,10 @@ export default class TextareaAutosize extends React.Component {
   componentWillUnmount() {
     //remove any scheduled events to prevent manipulating the node after it's
     //been unmounted
+    this.clearNextFrame();
+  }
+
+  clearNextFrame() {
     if (this.onNextFrameActionId) {
       clearNextFrameAction(this.onNextFrameActionId);
     }


### PR DESCRIPTION
This resolves an error we were seeing in our unit tests.
Two rapid prop changes followed by an unmount would cause
an error, since only the second would be cancelled.