### PR TITLE
React 0.14.0 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "license": "MIT",
   "main": "lib/TextareaAutosize.js",
   "peerDependencies": {
-    "react": ">= 0.13.0 || ^0.14.0-alpha"
+    "react": ">= 0.13.0 || ^0.14.0-alpha",
+    "react-dom": "^0.14.0-alpha"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "license": "MIT",
   "main": "lib/TextareaAutosize.js",
   "peerDependencies": {
-    "react": ">= 0.13.0 || ^0.14.0-alpha",
-    "react-dom": "^0.14.0-alpha"
+    "react": ">= 0.13.0 || ^0.14.0-beta3",
+    "react-dom": "^0.14.0-beta3"
   },
   "repository": {
     "type": "git",

--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -105,8 +105,8 @@ export default class TextareaAutosize extends React.Component {
   }
 
   componentWillUnmount() {
-    //remove any scheduled events to prevent manipulating the node after it's
-    //been unmounted
+    // remove any scheduled events to prevent manipulating the node after it's
+    // been unmounted
     this.clearNextFrame();
   }
 
@@ -137,6 +137,7 @@ export default class TextareaAutosize extends React.Component {
 
   /**
    * Read the current value of <textarea /> from DOM.
+   * @return {String} value of <textarea />
    */
   get value(): string {
     return ReactDOM.findDOMNode(this).value;
@@ -144,6 +145,7 @@ export default class TextareaAutosize extends React.Component {
 
   /**
    * Put focus on a <textarea /> DOM element.
+   * @returns {undefined} No return value
    */
   focus() {
     ReactDOM.findDOMNode(this).focus();

--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -3,8 +3,10 @@
  */
 
 import React from 'react';
-import emptyFunction from 'react/lib/emptyFunction';
+import ReactDOM from 'react-dom';
 import calculateNodeHeight from './calculateNodeHeight';
+
+const emptyFunction = () => {};
 
 export default class TextareaAutosize extends React.Component {
 
@@ -127,7 +129,7 @@ export default class TextareaAutosize extends React.Component {
   _resizeComponent() {
     let {useCacheForDOMMeasurements} = this.props;
     this.setState(calculateNodeHeight(
-      React.findDOMNode(this),
+      ReactDOM.findDOMNode(this),
       useCacheForDOMMeasurements,
       this.props.rows || this.props.minRows,
       this.props.maxRows));
@@ -137,14 +139,14 @@ export default class TextareaAutosize extends React.Component {
    * Read the current value of <textarea /> from DOM.
    */
   get value(): string {
-    return React.findDOMNode(this).value;
+    return ReactDOM.findDOMNode(this).value;
   }
 
   /**
    * Put focus on a <textarea /> DOM element.
    */
   focus() {
-    React.findDOMNode(this).focus();
+    ReactDOM.findDOMNode(this).focus();
   }
 
 }


### PR DESCRIPTION
Fixed #43 

* removed `react/lib/emptyFunction` dependency (seems to be deprecated in 0.14.0-beta3)
* added `react-dom` for `findDOMNode`
* bumped peer-dependency versions