### PR TITLE
fix(calculateNodeHeight): prevent return 0 for empty textareas

### DIFF
--- a/src/calculateNodeHeight.js
+++ b/src/calculateNodeHeight.js
@@ -50,7 +50,7 @@ export default function calculateNodeHeight(uiTextNode,
   // text-lines will not calculated properly as the shadow will technically be
   // narrower for content
   hiddenTextarea.setAttribute('style', sizingStyle + ';' + HIDDEN_TEXTAREA_STYLE);
-  hiddenTextarea.value = uiTextNode.value;
+  hiddenTextarea.value = uiTextNode.value ? uiTextNode.value : 'x';
 
   let minHeight = -Infinity;
   let maxHeight = Infinity;


### PR DESCRIPTION
If I remember correctly we did this change in Belle, because some IE versions the height will have scrollHeight of `0` in case the textarea has no value. I can double check this change tomorrow with a Windows computer.