### PR TITLE
Add text-rendering CSS property

### DIFF
--- a/src/calculateNodeHeight.js
+++ b/src/calculateNodeHeight.js
@@ -20,6 +20,7 @@ const SIZING_STYLE = [
   'font-family',
   'font-weight',
   'font-size',
+  'text-rendering',
   'text-transform',
   'width',
   'padding-left',


### PR DESCRIPTION
Using `text-rendering: optimizeLegibility` enables kerning and optional
ligatures, which may affect text metrics.

Here's an example of a pathological case of kerning:

##### `text-rendering: auto` (default)
![screen shot 2015-09-14 at 6 30 59 pm](https://cloud.githubusercontent.com/assets/240770/9863539/e2cee3ba-5b0e-11e5-8d1f-6706defa85d7.png)

##### `text-rendering: optimizeLegibility`
![screen shot 2015-09-14 at 6 31 11 pm](https://cloud.githubusercontent.com/assets/240770/9863543/e8e37018-5b0e-11e5-8186-74af6e89a302.png)
