### PR TITLE
Getting rid of React-v0.14 warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-textarea-autosize",
   "description": "textarea component for React which grows with content",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": {
     "name": "Andrey Popp",
     "email": "8mayday@gmail.com",

--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -78,7 +78,7 @@ export default class TextareaAutosize extends React.Component {
     }
     props.style = {
       ...props.style,
-      height: this.state.height
+      height: this.state.height || 0
     };
     let maxHeight = Math.max(
       props.style.maxHeight ? props.style.maxHeight : Infinity,


### PR DESCRIPTION
Get rid of React-v0.14 warning that '...style object that has previously been mutated. Mutating  is deprecated...' by preventing height to be set to NaN (e.g. when testing)