### PR TITLE
Fix resize error in ie11 when textarea is empty

### DIFF
--- a/src/calculateNodeHeight.js
+++ b/src/calculateNodeHeight.js
@@ -69,7 +69,7 @@ export default function calculateNodeHeight(uiTextNode,
 
   if (minRows !== null || maxRows !== null) {
     // measure height of a textarea with a single row
-    hiddenTextarea.value = '';
+    hiddenTextarea.value = '\uFEFF';
     let singleRowHeight = hiddenTextarea.scrollHeight - paddingSize;
     if (minRows !== null) {
       minHeight = singleRowHeight * minRows;


### PR DESCRIPTION
It's for #74