### PR TITLE
Update to support horizontal overflow

### DIFF
--- a/src/calculateNodeHeight.js
+++ b/src/calculateNodeHeight.js
@@ -7,7 +7,7 @@ const HIDDEN_TEXTAREA_STYLE = `
   max-height:none !important;
   height:0 !important;
   visibility:hidden !important;
-  overflow:hidden !important;
+  overflow-y:hidden !important;
   position:absolute !important;
   z-index:-1000 !important;
   top:0 !important;
@@ -28,7 +28,10 @@ const SIZING_STYLE = [
   'padding-left',
   'padding-right',
   'border-width',
-  'box-sizing'
+  'box-sizing',
+  'word-wrap',
+  'overflow-x',
+  'white-space'
 ];
 
 let computedStyleCache = {};


### PR DESCRIPTION
This is useful for `textarea` elements that contain code, but with line lengths greater than the `textarea`'s width
