### PR TITLE
provide public interface for event listener on textarea

### DIFF
--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -126,6 +126,10 @@ export default class TextareaAutosize extends React.Component {
     }
   }
 
+  addEventListener(type, listener, useCapture) {
+    this._rootDOMNode.addEventListener(type, listener, useCapture)
+  }
+
   _onRootDOMNode(node) {
     this._rootDOMNode = node;
   }


### PR DESCRIPTION
Hi,

thanks for the great component,
I have found myself with an issue when trying to tie a `Rx.Observable.fromEvent` on this component, and I tried to explore pushing back the `ref` to the `_rootDOMNode` but that seemed to fail on the long run, also it seemed to be a not public property.

This solution fixes the issue, and has probably more semantic sense. 

If you are happy with it, please merge, otherwise I'll work towards another solution.

Thanks
