### PR TITLE
'none' is not a valid value for min-height

### DIFF
--- a/src/calculateNodeHeight.js
+++ b/src/calculateNodeHeight.js
@@ -3,7 +3,7 @@
  */
 
 const HIDDEN_TEXTAREA_STYLE = `
-  min-height:none !important;
+  min-height:0 !important;
   max-height:none !important;
   height:0 !important;
   visibility:hidden !important;


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/min-height

Here's an example of a site that has a global textarea style that sets min-height and ignores the invalid inlined min-height style.

![developer_tools](https://cloud.githubusercontent.com/assets/160978/13988537/c7d6877e-f0e2-11e5-87e2-6819d3fd6c22.png)
