### PR TITLE
Remove requestAnimationFrame

### DIFF
--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -63,7 +63,6 @@ export default class TextareaAutosize extends React.Component {
       minHeight: -Infinity,
       maxHeight: Infinity
     };
-    this._onNextFrameActionId = null;
     this._rootDOMNode = null;
     this._onChange = this._onChange.bind(this);
     this._resizeComponent = this._resizeComponent.bind(this);
@@ -102,8 +101,7 @@ export default class TextareaAutosize extends React.Component {
 
   componentWillReceiveProps() {
     // Re-render with the new content then recalculate the height as required.
-    this._clearNextFrame();
-    this._onNextFrameActionId = onNextFrame(this._resizeComponent);
+    this._resizeComponent();
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -116,14 +114,7 @@ export default class TextareaAutosize extends React.Component {
   componentWillUnmount() {
     // Remove any scheduled events to prevent manipulating the node after it's
     // been unmounted.
-    this._clearNextFrame();
     window.removeEventListener('resize', this._resizeComponent);
-  }
-
-  _clearNextFrame() {
-    if (this._onNextFrameActionId) {
-      clearNextFrameAction(this._onNextFrameActionId);
-    }
   }
 
   _onRootDOMNode(node) {
@@ -205,19 +196,4 @@ export default class TextareaAutosize extends React.Component {
     this._rootDOMNode.blur();
   }
 
-}
-
-function onNextFrame(cb) {
-  if (window.requestAnimationFrame) {
-    return window.requestAnimationFrame(cb);
-  }
-  return window.setTimeout(cb, 1);
-}
-
-function clearNextFrameAction(nextFrameId) {
-  if (window.cancelAnimationFrame) {
-    window.cancelAnimationFrame(nextFrameId);
-  } else {
-    window.clearTimeout(nextFrameId);
-  }
 }


### PR DESCRIPTION
Using requestAnimationFrame makes the textarea not work correctly
in IE11 with React 15 in controlled mode. It causes the textarea to drop keystrokes
when typing quickly. The current demo site is using React 14 which doesn't seem to have the issue. Upgrading the demo page to React 15 causes the problem to happen.

Demo gif of the problem typing `hahahahahahaha` here:

![ie11](https://cldup.com/GXJURXX91W.gif)

I'm assuming the rAF code was added for a very specific reason or else it wouldn't be there, so I'm just opening this PR as a demo to show the problem with a fix.
