### PR TITLE
fix: removal of babel config from package.json

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "presets": [
+    "prometheusresearch"
+  ]
+}

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ src
 example
 Makefile
 npm-debug.log
+.babelrc

--- a/package.json
+++ b/package.json
@@ -11,11 +11,6 @@
   "eslintConfig": {
     "extends": "prometheusresearch"
   },
-  "babel": {
-    "presets": [
-      "prometheusresearch"
-    ]
-  },
   "keywords": [
     "react",
     "react-component",


### PR DESCRIPTION
The babel setup used by this package does not work with different setups. This PR tries to fix this by using the `.babelrc` file for local development and ignoring it for the npm package.