### PR TITLE
fix #91 retrieve textarea dom node

### DIFF
--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -205,6 +205,15 @@ export default class TextareaAutosize extends React.Component {
     this._rootDOMNode.blur();
   }
 
+  /**
+   * Convenience method to retrieve the textarea node.
+   * <Textarea ref = "area" />
+   * let node = this.refs.area.getTextareaDOMNode();
+   */
+  getTextareaDOMNode() {
+    return this._rootDOMNode;
+  }
+
 }
 
 function onNextFrame(cb) {


### PR DESCRIPTION
This exposes the `_rootDOMNode` to anyone who needs it, as explained [here](https://facebook.github.io/react/docs/more-about-refs.html).

 Example

``` javascript
import React from 'react';
import Textarea from 'react-textarea-autosize';

class Example extends React.Component {
  render() {
    <div onClick = {this._onClick}>
      <Textarea ref = 'area'/>
    </div>
  }

  _onClick(e) {
    let node = this.refs.area.getTextareaDOMNode();
    // do something special with the node here.
    // you can also use a function for the ref instead.
  }
}
```
