### PR TITLE
Set initial height to be any given props.style.height

### DIFF
--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -59,7 +59,7 @@ export default class TextareaAutosize extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      height: null,
+      height: (props.style && props.style.height) || 0,
       minHeight: -Infinity,
       maxHeight: Infinity
     };
@@ -78,7 +78,7 @@ export default class TextareaAutosize extends React.Component {
     }
     props.style = {
       ...props.style,
-      height: this.state.height || (props.style && props.style.height) || 0,
+      height: this.state.height,
     };
     let maxHeight = Math.max(
       props.style.maxHeight ? props.style.maxHeight : Infinity,

--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -78,7 +78,7 @@ export default class TextareaAutosize extends React.Component {
     }
     props.style = {
       ...props.style,
-      height: this.state.height || 0,
+      height: this.state.height || (props.style && props.style.height) || 0,
     };
     let maxHeight = Math.max(
       props.style.maxHeight ? props.style.maxHeight : Infinity,


### PR DESCRIPTION
I'm using react-textarea-autosize for server-side rendering and the default style.height value is 0.

This patch enables user to pass their own props.style.height values for initial height.
