### PR TITLE
Removes unknown props for React 15.2 compatibility

### DIFF
--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -73,6 +73,9 @@ export default class TextareaAutosize extends React.Component {
   render() {
     let {valueLink, ...props} = this.props;
     props = {...props};
+    // Remove unknown props https://fb.me/react-unknown-prop
+    delete props.onHeightChange;
+    delete props.useCacheForDOMMeasurements;
     if (typeof valueLink === 'object') {
       props.value = this.props.valueLink.value;
     }


### PR DESCRIPTION
Fixes the following warning from React 15.2:

`Warning: Unknown props `onHeightChange`, `useCacheForDOMMeasurements` on <textarea> tag. Remove these props from the element.`