### PR TITLE
Fix 'react-unknown-prop'

### DIFF
--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -6,6 +6,7 @@ import React from 'react';
 import calculateNodeHeight from './calculateNodeHeight';
 
 const emptyFunction = function() {};
+const blacklistProps = ['onHeightChange', 'useCacheForDOMMeasurements', 'minRows', 'maxRows'];
 
 export default class TextareaAutosize extends React.Component {
 
@@ -92,9 +93,18 @@ export default class TextareaAutosize extends React.Component {
     if (maxHeight < this.state.height) {
       props.style.overflow = 'hidden';
     }
+
+    const filteredProps = Object.keys(props).reduce((acc, prop) => {
+      if (blacklistProps.indexOf(prop) === -1) {
+        acc[prop] = props[prop];
+      }
+
+      return acc;
+    }, {});
+
     return (
       <textarea
-        {...props}
+        {...filteredProps}
         onChange={this._onChange}
         ref={this._onRootDOMNode}
         />


### PR DESCRIPTION
Fix to #112. Add blacklist of props which shouldn't pass to textarea.