### PR TITLE
chore(*): Install rollup and build umd

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
   "presets": [
-    "prometheusresearch"
+    "es2015", "stage-1", "react"
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ TESTS = $(wildcard src/__tests__/*-test.js)
 BABEL_OPTS = \
 	--sourceMaps=inline
 
-build: $(LIB)
+build: $(LIB) build-min
 
 test::
 	@echo No tests...
@@ -15,7 +15,7 @@ lint::
 	@$(BIN)/eslint $(SRC)
 
 clean:
-	@rm -f $(LIB)
+	@rm -rf lib/
 
 sloc:
 	@$(BIN)/sloc ./src
@@ -34,6 +34,10 @@ release = npm version $(1)
 publish: build
 	@git push --tags origin HEAD:master
 	@npm publish
+
+build-min: $(LIB)
+	@echo "building lib/TextareaAutosize.min.js"
+	@$(BIN)/rollup -c
 
 lib/%.js: src/%.js
 	@echo "building $@"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",
+    "babel-preset-es2015": "^6.18.0",
+    "babel-preset-es2015-rollup": "^1.2.0",
     "babel-preset-prometheusresearch": "^0.1.0",
+    "babel-preset-react": "^6.16.0",
+    "babel-preset-stage-1": "^6.16.0",
     "babelify": "^7.3.0",
     "browserify": "^13.1.0",
     "eslint": "^3.3.1",
@@ -23,6 +27,8 @@
     "eslint-plugin-react": "^6.1.2",
     "react": "^15.3.1",
     "react-dom": "^15.3.1",
+    "rollup": "^0.36.3",
+    "rollup-plugin-babel": "^2.6.1",
     "watchify": "^3.7.0"
   },
   "files": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,21 @@
+import babel from 'rollup-plugin-babel';
+
+export default {
+  entry: 'src/TextareaAutosize.js',
+  dest: 'lib/TextareaAutosize.min.js',
+  format: 'umd',
+  moduleName: 'TextareaAutosize',
+  plugins: [
+    babel({
+      babelrc: false,
+      presets: ['es2015-rollup', 'stage-1', 'react'],
+      exclude: 'node_modules/**',
+    }),
+  ],
+  external: [
+    'react',
+  ],
+  globals: {
+    react: 'React',
+  },
+};


### PR DESCRIPTION
It looks like the build files assume that the consumer is using the CommonJS module format. I didn't see a UMD build, so this PR introduces one. I'm relying on Rollup to do the module bundling. 

Without the UMD build, using this module within ClojureScript wasn't really possible.