### PR TITLE
Fix onChange behavior on ie11

### DIFF
--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -95,7 +95,7 @@ export default class TextareaAutosize extends React.Component {
     return (
       <textarea
         {...props}
-        onChange={this._onChange}
+        onInput={this._onChange}
         ref={this._onRootDOMNode}
         />
     );


### PR DESCRIPTION
`onChange` doesn't trigger correctly on IE11 in react 15 for inputs/textareas. `onInput` seems to work fine - I tested in IE10, 11, Chrome, Firefox and Safari.
There is a fix in the working here https://github.com/facebook/react/pull/8575 - also a good source of info on related issues