### PR TITLE
Do not call _resizeComponent before the component is even updated. It…

### DIFF
--- a/src/TextareaAutosize.js
+++ b/src/TextareaAutosize.js
@@ -137,7 +137,6 @@ export default class TextareaAutosize extends React.Component {
   }
 
   _onChange(e) {
-    this._resizeComponent();
     let {valueLink, onChange} = this.props;
     if (valueLink) {
       valueLink.requestChange(e.target.value);


### PR DESCRIPTION
…'s useless and may trigger additional renderings leading to cursor jumps when change is rendered async


I don't really understand why this was called directly. What's the point of computing the height just before applying the change (it will be computed later when component receive parent props so it's not really needed)


If your state is hold by a parent, and the call to setState triggers an async rendering, then this line will actually make the cursor jump at the end of the input