### PR TITLE
add focus function to focus the inner textarea DOM element

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,4 +164,8 @@ export default class TextareaAutosize extends React.Component {
 
     callback();
   };
+
+  focus = () => {
+    this._rootDOMNode.focus();
+  };
 }


### PR DESCRIPTION
Currently there's no way to focus the textarea without accessing `_rootDOMNode`. It used to have focus() function on version 4.