### PR TITLE
docs: describe a way to set focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ https://andreypopp.github.io/react-textarea-autosize/
 
 ## FAQ
 
+### How to focus
+
+Get a ref to inner textarea:
+```js
+<Textarea inputRef={(tag) => this.textarea = tag} />
+```
+And then call a focus on that ref:
+```js
+this.textarea.focus()
+```
+
 ### How to test it with jest and react-test-renderer
 
 Because [jest](https://github.com/facebook/jest) provides polyfills for DOM


### PR DESCRIPTION
I needed to set autofocus and had to look in the source for a way.

Perhaps it would be nice to also add a `autoFocus` prop that would set focus in `componentDidMount`. If you like this idea, I would prepare a PR.

Warm greetings!