### PR TITLE
Guard against `this._rootDOMNode === null`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,7 @@ export default class TextareaAutosize extends React.Component {
   };
 
   _resizeComponent = (callback = noop) => {
-    if (typeof this._rootDOMNode === 'undefined') {
+    if (!this._rootDOMNode) {
       callback();
       return;
     }


### PR DESCRIPTION
Fixes (probably): #157

I have the same issue as reported in that issue without using shallow render - I use [`storyshots`](https://github.com/storybooks/storybook/tree/master/addons/storyshots) where I have no control over the rendering.