### PR TITLE
fixed height=undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,10 +64,12 @@ export default class TextareaAutosize extends React.Component {
       useCacheForDOMMeasurements: _useCacheForDOMMeasurements,
       ...props
     } = this.props;
-
+    
+    const height = this.state.height || (props.style && props.style.height) ? props.style.height : 'auto';
+    
     props.style = {
       ...props.style,
-      height: this.state.height,
+      height,
     };
 
     let maxHeight = Math.max(


### PR DESCRIPTION
In use with https://github.com/emotion-js/emotion/ there is an `console.error` `Warning: 'NaN' is an invalid value for the 'height' css style property.`. To fix that, it shall always give a valid height instead of `undefined`.