### PR TITLE
allows calculateNodeHeight function to be accessed externally

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -171,3 +171,6 @@ export default class TextareaAutosize extends React.Component {
     callback();
   };
 }
+
+// Exports calculateNodeHeight function to be accessible externally
+export { default as calculateNodeHeight } from './calculateNodeHeight';


### PR DESCRIPTION
### Description
We use the library because we have a textarea which expands as user types longer content.
But there's an wrapper called `Collapsible` which literally toggles the text area to be open or closed
when the user clicks a button

````js
const MIN_ROW_COUNT = 1

<Collapsible isDefaultClosed={this.props.isDefaultClosed}>
  {({ isOpen, toggle }) => (
    <TextareaAutosize
      minRows={MIN_ROW_COUNT}
      maxRows={isOpen ? undefined : MIN_ROW_COUNT}
      useCacheForDOMMeasurements={true}
    />

    {(this.state.rowCount > MIN_ROW_COUNT || !isOpen) && (
      <Button
        onClick={toggle}
        label={this.props.intl.formatMessage(
          messages[isOpen ? 'collapse' : 'expand']
        )}
      />
    )}
  )}
</Collapsible>
````

#### The problem
There's an option called `isDefaultClosed`, which means the component will be closed
when mounted no matter the content. But I need to render the "Expand/Collapse" 
button only when the content is bigger than one row. At the moment I can't do it
since I pass the maxRows from outside, and therefore it will always change the "height" calculation
based on the passed rows, leaving me no option to rely on the innerComponent anymore.

#### Solution
Since the logic for the button is external and whatever I'm passing it is changing its internal values
I need to somehow have this externally. I could then check if `isDefaultClosed` is passed and
if the content breaks into more than one row (with external function) and so I can render the button


#### Why I need the solution proposed in this PR
Accessing this function will allow me to check what is the height of the content
beforehands and check if I should render the "Expand/Collapse" button or not
as well as avoid me to recreate the same logic in another function
