### PR TITLE
Remove the hiddenTextArea from the document.body after it has been measured

### DIFF
--- a/src/calculateNodeHeight.js
+++ b/src/calculateNodeHeight.js
@@ -66,6 +66,7 @@ export default function calculateNodeHeight(
   const nodeStyling = calculateNodeStyling(uiTextNode, uid, useCache);
 
   if (nodeStyling === null) {
+    hiddenTextarea.parentNode.removeChild(hiddenTextarea);
     return null;
   }
 
@@ -116,8 +117,9 @@ export default function calculateNodeHeight(
     height = Math.min(maxHeight, height);
   }
 
+  hiddenTextarea.parentNode.removeChild(hiddenTextarea);
   const rowCount = Math.floor(height / singleRowHeight);
-
+  
   return { height, minHeight, maxHeight, rowCount, valueRowCount };
 }
 


### PR DESCRIPTION
We don't want the document.body to fill up with extra elements over time (memory leak), so this change removes the hidden textarea after it has been measured.

Test plan: Ran the tests, verified everything still works.