### PR TITLE
Proposal: Allow callers to avoid subpixel height values

### DIFF
--- a/src/calculateNodeHeight.js
+++ b/src/calculateNodeHeight.js
@@ -56,6 +56,7 @@ export default function calculateNodeHeight(
   useCache = false,
   minRows = null,
   maxRows = null,
+  avoidSubpixelHeight = false,
 ) {
   if (hiddenTextarea.parentNode === null) {
     document.body.appendChild(hiddenTextarea);
@@ -118,7 +119,7 @@ export default function calculateNodeHeight(
 
   const rowCount = Math.floor(height / singleRowHeight);
 
-  return { height, minHeight, maxHeight, rowCount, valueRowCount };
+  return { height: avoidSubpixelHeight ? Math.ceil(height) : height, minHeight, maxHeight, rowCount, valueRowCount };
 }
 
 function calculateNodeStyling(node, uid, useCache = false) {

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ let uid = 0;
 
 export default class TextareaAutosize extends React.Component {
   static propTypes = {
+    avoidSubpixelHeight: PropTypes.bool,
     inputRef: PropTypes.oneOfType([
       PropTypes.func,
       PropTypes.shape({
@@ -28,6 +29,7 @@ export default class TextareaAutosize extends React.Component {
   };
 
   static defaultProps = {
+    avoidSubpixelHeight: false,
     inputRef: noop,
     onChange: noop,
     onHeightChange: noop,
@@ -134,6 +136,7 @@ export default class TextareaAutosize extends React.Component {
       this.props.useCacheForDOMMeasurements,
       this.props.minRows,
       this.props.maxRows,
+      this.props.avoidSubpixelHeight,
     );
 
     if (nodeHeight === null) {


### PR DESCRIPTION
Subpixel rendering behavior depends on the browser and often isn't perfect (sometimes creating misalignment in layouts). This is a proposal to allow users to pass an `avoidSubpixelHeight` prop that will avoid subpixel height values by `ceil`ing the computed height (I think it's better to `ceil`, as opposed to `round`, so we don't decrease the height and potentially cut off some of the content).

Totally understand if you'd rather not include this to avoid bloating the API.

Thanks for the work (and apologies if this has been discussed before).