### PR TITLE
Fix issue 251 add a11y ignore to hidden text area

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Drop-in replacement for the textarea component which automatically resizes
 textarea as content changes. A native React version of the popular
 [jQuery Autosize](http://www.jacklmoore.com/autosize/)! Weighs
-<span class="weight">1.65KB</span> (minified & gzipped).
+<span class="weight">1.68KB</span> (minified & gzipped).
 
 This module supports IE9 and above.
 

--- a/src/calculateNodeHeight.js
+++ b/src/calculateNodeHeight.js
@@ -1,3 +1,4 @@
+/* global window document */
 import isBrowser from './isBrowser.macro';
 
 const isIE = isBrowser ? !!document.documentElement.currentStyle : false;
@@ -39,6 +40,8 @@ const SIZING_STYLE = [
 
 let computedStyleCache = {};
 const hiddenTextarea = isBrowser && document.createElement('textarea');
+hiddenTextarea.setAttribute('tab-index', '-1');
+hiddenTextarea.setAttribute('aria-hidden', 'true');
 
 const forceHiddenStyles = node => {
   Object.keys(HIDDEN_TEXTAREA_STYLE).forEach(key => {


### PR DESCRIPTION
**what is the change?:**
Make the hidden text area non-tabbable and hidden from screen readers.

**why make this change?:**
It violates some AA WCAG2 guidelines, as per this output from Pa11y:
```
      {
        "code": "WCAG2AA.Principle4.Guideline4_1.4_1_2.H91.Textarea.Name",
        "context": "<textarea style=\"min-height: 0px !important; max-height: none !important; height: 0px !important; visibility: hidden !important; overflow: hidden !important; position: absolute !important; z-index: -1000 !important; top: 0px !important; right: 0px !i...",
        "message": "This textarea element does not have a name available to an accessibility API. Valid names are: label element, title undefined, aria-label undefined, aria-labelledby undefined.",
        "type": "error",
        "typeCode": 1,
        "selector": "...(omitted)"
      },
      {
        "code": "WCAG2AA.Principle1.Guideline1_3.1_3_1.F68",
        "context": "<textarea style=\"min-height: 0px !important; max-height: none !important; height: 0px !important; visibility: hidden !important; overflow: hidden !important; position: absolute !important; z-index: -1000 !important; top: 0px !important; right: 0px !i...",
        "message": "This form field should be labelled in some way. Use the label element (either with a \"for\" attribute or wrapped around the form field), or \"title\", \"aria-label\" or \"aria-labelledby\" attributes as appropriate.",
        "type": "error",
        "typeCode": 1,
        "selector": "...(omitted)"
      }
```

**test plan:**
We tested this change in our own product and Pa11y stopped flagging the
violation.

**issue:**
https://github.com/andreypopp/react-textarea-autosize/issues/251